### PR TITLE
Add support for functionless sorting of items

### DIFF
--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -150,6 +150,12 @@ def test_hosts_sort():
         == Hosts((Host("1.1.1.1"), Host("1.2.3.4"), Host("2.2.2.2")))
     )
 
+    assert (
+        Hosts.from_file(CSV_FILE).sort(reverse=True)
+        == Hosts.from_file(CSV_FILE).sort(lambda h: h.ip, reverse=True)
+        == Hosts((Host("2.2.2.2"), Host("1.2.3.4"), Host("1.1.1.1")))
+    )
+
 
 def test_hosts_task():
 
@@ -175,3 +181,15 @@ def test_hosts_run_task(Runners, Task):
     Runners.from_items().run.assert_called_with(max_workers=3)
 
     assert hosts.results() == Results.from_items()
+
+
+def test_hosts_order_by():
+    assert Hosts.from_file(CSV_FILE).order_by("ip") == Hosts(
+        (Host("1.1.1.1"), Host("1.2.3.4"), Host("2.2.2.2"))
+    )
+    assert Hosts.from_file(CSV_FILE).order_by("ip", reverse=True) == Hosts(
+        (Host("2.2.2.2"), Host("1.2.3.4"), Host("1.1.1.1"))
+    )
+    assert Hosts.from_file(CSV_FILE).order_by("hostname", "ip") == Hosts(
+        (Host("1.1.1.1"), Host("1.2.3.4"), Host("2.2.2.2"))
+    )

--- a/viper/__init__.py
+++ b/viper/__init__.py
@@ -3,7 +3,7 @@ __description__ = "Viper is a handy tool for easily running infrastructure manag
 __email__ = "sayanarijit@gmail.com"
 __homepage__ = "https://github.com/sayanarijit/viper"
 __license__ = "MIT"
-__version__ = "v0.26.1"
+__version__ = "v0.27.0"
 
 from viper.collections import Host  # noqa: F401
 from viper.collections import Hosts  # noqa: F401

--- a/viper/cli.py
+++ b/viper/cli.py
@@ -500,17 +500,47 @@ class HostsCountCommand(SubCommand):
         return 0
 
 
+class HostsOrderByCommand(SubCommand):
+    """[Hosts -> Hosts] sort the hosts by the given properties"""
+
+    name = "hosts:order-by"
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "properties", nargs="*", help="items will be sorted in order"
+        )
+        parser.add_argument(
+            "--reverse", action="store_true", help="reverse the order after sort"
+        )
+        parser.add_argument("-i", "--indent", type=int, default=None)
+
+    def __call__(self, args: Namespace) -> int:
+        print(
+            Hosts.from_json(input())
+            .order_by(*args.properties, reverse=args.reverse)
+            .to_json(indent=args.indent)
+        )
+        return 0
+
+
 class HostsSortCommand(SubCommand):
-    """[Hosts -> Hosts] sort the hosts"""
+    """[Hosts -> Hosts] sort the hosts by the given function"""
 
     name = "hosts:sort"
 
     def add_arguments(self, parser: ArgumentParser) -> None:
-        parser.add_argument("--key", type=func)
+        parser.add_argument("--key", type=func, help="the sorting function")
+        parser.add_argument(
+            "--reverse", action="store_true", help="reverse the order after sort"
+        )
         parser.add_argument("-i", "--indent", type=int, default=None)
 
     def __call__(self, args: Namespace) -> int:
-        print(Hosts.from_json(input()).sort(key=args.key).to_json(indent=args.indent))
+        print(
+            Hosts.from_json(input())
+            .sort(key=args.key, reverse=args.reverse)
+            .to_json(indent=args.indent)
+        )
         return 0
 
 
@@ -653,17 +683,47 @@ class RunnersCountCommand(SubCommand):
         return 0
 
 
+class RunnersOrderByCommand(SubCommand):
+    """[Runners -> Runners] sort the runners by the given properties"""
+
+    name = "runners:order-by"
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "properties", nargs="*", help="items will be sorted in order"
+        )
+        parser.add_argument(
+            "--reverse", action="store_true", help="reverse the order after sort"
+        )
+        parser.add_argument("-i", "--indent", type=int, default=None)
+
+    def __call__(self, args: Namespace) -> int:
+        print(
+            Runners.from_json(input())
+            .order_by(*args.properties, reverse=args.reverse)
+            .to_json(indent=args.indent)
+        )
+        return 0
+
+
 class RunnersSortCommand(SubCommand):
-    """[Runners -> Runners] sort the runners"""
+    """[Runners -> Runners] sort the runners by the given funtion"""
 
     name = "runners:sort"
 
     def add_arguments(self, parser: ArgumentParser) -> None:
         parser.add_argument("--key", type=func)
+        parser.add_argument(
+            "--reverse", action="store_true", help="reverse the order after sort"
+        )
         parser.add_argument("-i", "--indent", type=int, default=None)
 
     def __call__(self, args: Namespace) -> int:
-        print(Runners.from_json(input()).sort(key=args.key).to_json(indent=args.indent))
+        print(
+            Runners.from_json(input())
+            .sort(key=args.key, reverse=args.reverse)
+            .to_json(indent=args.indent)
+        )
         return 0
 
 
@@ -845,17 +905,47 @@ class ResultsCountCommand(SubCommand):
         return 0
 
 
+class ResultsOrderByCommand(SubCommand):
+    """[Results -> Results] sort the results by the given properties"""
+
+    name = "results:order-by"
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "properties", nargs="*", help="items will be sorted in order"
+        )
+        parser.add_argument(
+            "--reverse", action="store_true", help="reverse the order after sort"
+        )
+        parser.add_argument("-i", "--indent", type=int, default=None)
+
+    def __call__(self, args: Namespace) -> int:
+        print(
+            Results.from_json(input())
+            .order_by(*args.properties, reverse=args.reverse)
+            .to_json(indent=args.indent)
+        )
+        return 0
+
+
 class ResultsSortCommand(SubCommand):
-    """[Results -> Results] sort the results"""
+    """[Results -> Results] sort the results by the given function"""
 
     name = "results:sort"
 
     def add_arguments(self, parser: ArgumentParser) -> None:
         parser.add_argument("--key", type=func)
+        parser.add_argument(
+            "--reverse", action="store_true", help="reverse the order after sort"
+        )
         parser.add_argument("-i", "--indent", type=int, default=None)
 
     def __call__(self, args: Namespace) -> int:
-        print(Results.from_json(input()).sort(key=args.key).to_json(indent=args.indent))
+        print(
+            Results.from_json(input())
+            .sort(key=args.key, reverse=args.reverse)
+            .to_json(indent=args.indent)
+        )
         return 0
 
 
@@ -1057,12 +1147,13 @@ def run() -> int:
     HostsFromFileCommand.attach_to(subparsers)
     HostsFromFuncCommand.attach_to(subparsers)
 
+    HostsWhereCommand.attach_to(subparsers)
     HostsFilterCommand.attach_to(subparsers)
-    HostsCountCommand.attach_to(subparsers)
+    HostsOrderByCommand.attach_to(subparsers)
     HostsSortCommand.attach_to(subparsers)
+    HostsCountCommand.attach_to(subparsers)
     HostsPipeCommand.attach_to(subparsers)
     HostsFormatCommand.attach_to(subparsers)
-    HostsWhereCommand.attach_to(subparsers)
     HostsHeadCommand.attach_to(subparsers)
     HostsTailCommand.attach_to(subparsers)
 
@@ -1071,12 +1162,13 @@ def run() -> int:
     HostsResultsCommand.attach_to(subparsers)
 
     # Task runners commands
+    RunnersWhereCommand.attach_to(subparsers)
     RunnersFilterCommand.attach_to(subparsers)
-    RunnersCountCommand.attach_to(subparsers)
+    RunnersOrderByCommand.attach_to(subparsers)
     RunnersSortCommand.attach_to(subparsers)
+    RunnersCountCommand.attach_to(subparsers)
     RunnersPipeCommand.attach_to(subparsers)
     RunnersFormatCommand.attach_to(subparsers)
-    RunnersWhereCommand.attach_to(subparsers)
     RunnersHeadCommand.attach_to(subparsers)
     RunnersTailCommand.attach_to(subparsers)
 
@@ -1086,12 +1178,13 @@ def run() -> int:
     # Task results commands
     ResultsFromHistoryCommand.attach_to(subparsers)
 
+    ResultsWhereCommand.attach_to(subparsers)
     ResultsFilterCommand.attach_to(subparsers)
-    ResultsCountCommand.attach_to(subparsers)
+    ResultsOrderByCommand.attach_to(subparsers)
     ResultsSortCommand.attach_to(subparsers)
+    ResultsCountCommand.attach_to(subparsers)
     ResultsPipeCommand.attach_to(subparsers)
     ResultsFormatCommand.attach_to(subparsers)
-    ResultsWhereCommand.attach_to(subparsers)
     ResultsHeadCommand.attach_to(subparsers)
     ResultsTailCommand.attach_to(subparsers)
 

--- a/viper/collections.py
+++ b/viper/collections.py
@@ -383,13 +383,38 @@ class Items(Collection):
         return type(self).from_items(*self._all[i:j])
 
     def sort(
-        self: ItemsType, key: t.Optional[t.Callable[[Item], object]] = None
+        self: ItemsType,
+        key: t.Optional[t.Callable[[Item], object]] = None,
+        reverse: bool = False,
     ) -> ItemsType:
         """Sort the items by given key/function.
 
         :param callable key: A function similar to the one passed to the built-in `sorted()`.
+        :param bool reverse: Reverse the order after sort.
+
+        :rtype: Items
         """
-        return type(self)(tuple(sorted(self._all, key=key)))
+        return type(self)(tuple(sorted(self._all, key=key, reverse=reverse)))
+
+    def order_by(self: ItemsType, *properties: str, reverse: bool = False) -> ItemsType:
+        """Sort the items by multiple properties
+
+        :param list properties: The item will be sorted by the given properties in order.
+        :param bool reverse: Reverse the order after sort.
+
+        :rtype: Items
+        """
+        return type(self)(
+            tuple(
+                sorted(
+                    self._all,
+                    key=lambda x: [
+                        f"{{{p}}}".format(**x.to_dict()) for p in properties
+                    ],
+                    reverse=reverse,
+                )
+            )
+        )
 
     def filter(self: ItemsType, filter_: FilterType, *args: object) -> ItemsType:
         """Filter the items by a given function.


### PR DESCRIPTION
Use `.order_by` or `:order-by` to order the items by multiple
properties. Also add `--reverse` to reverse the order in both `.sort`
and `.order_by` and their command-line options.