### PR TITLE
Use a custom type for the meta field

### DIFF
--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -1,5 +1,6 @@
 from unittest import mock
 from viper import Host
+from viper import meta
 
 import json
 import pytest
@@ -45,15 +46,21 @@ def test_from_json():
                 "port": 22,
                 "login_name": None,
                 "identity_file": None,
-                "meta": {},
+                "meta": {"foo": "bar"},
             }
         )
-    ) == Host("1.1.1.1")
+    ) == Host("1.1.1.1", meta=meta(foo="bar"))
 
     with pytest.raises(ValueError) as e:
         Host.from_json("{}")
 
     assert "value is required" in str(e.__dict__)
+
+
+def test_getitem():
+    assert Host("1.1.1.1")["ip"] == "1.1.1.1"
+    with pytest.raises(KeyError):
+        Host("1.1.1.1")["foo"]
 
 
 def test_fqdn():

--- a/viper/__init__.py
+++ b/viper/__init__.py
@@ -7,6 +7,7 @@ __version__ = "v0.28.0"
 
 from viper.collections import Host  # noqa: F401
 from viper.collections import Hosts  # noqa: F401
+from viper.collections import meta  # noqa: F401
 from viper.collections import Result  # noqa: F401
 from viper.collections import Results  # noqa: F401
 from viper.collections import Runner  # noqa: F401
@@ -15,6 +16,7 @@ from viper.collections import Task  # noqa: F401
 from viper.collections import WhereConditions  # noqa: F401
 
 __all__ = [
+    "meta",
     "Host",
     "Hosts",
     "Result",

--- a/viper/demo/viperfile.py
+++ b/viper/demo/viperfile.py
@@ -28,6 +28,7 @@ from argparse import Namespace
 from time import ctime
 from viper import Host
 from viper import Hosts
+from viper import meta
 from viper import Result
 from viper import Results
 from viper import Runner
@@ -105,7 +106,7 @@ def allhosts(args: Namespace) -> Hosts:
             hostname=d["name"],
             login_name="root",
             identity_file=args.identity_file,
-            meta=tuple(d.items()),
+            meta=meta(**d),
         )
         for d in data
     )
@@ -127,9 +128,9 @@ def hosts2csv(hosts: Hosts, args: Namespace) -> Hosts:
     """
 
     writer = csv.writer(args.file)
-    writer.writerow(list(dict(hosts.all()[0].meta).keys()))
+    writer.writerow(hosts.all()[0].meta._fields)
     for host in hosts.all():
-        writer.writerow(list(dict(host.meta).values()))
+        writer.writerow(tuple(host.meta))
     args.file.flush()
     args.file.close()
 


### PR DESCRIPTION
Meta attrubutes were represented as dict. But behind the scene
it was a basic tuple. Let's use a custom variation of namedtuple
to avail some useful features such as dot notation support in `.format`
and `.order_by`.